### PR TITLE
Support Lucee logger config

### DIFF
--- a/models/BaseConfig.cfc
+++ b/models/BaseConfig.cfc
@@ -188,6 +188,8 @@ component accessors=true {
 	
 	// Key is virtual path, value is struct of properties
 	property name='CFMappings' type='struct' _isCFConfig=true;
+	// Key is log name, value is struct of properties
+	property name='loggers' type='struct' _isCFConfig=true;
 	// True/false
 	property name='errorStatusCode' type='boolean' _isCFConfig=true;
 	// True/false
@@ -737,7 +739,45 @@ component accessors=true {
 	* Add a single custom tag to the config
 	*/
 	function addCustomTagPath() { throw 'addCustomTagPath() not implemented'; }
-	
+
+	/**
+	* Add a single logger to the config
+	*
+	* @name name for the logger
+	* @appender resource or console
+	* @appenderArguments args for the appender
+	* @appenderClass A full class path to a Appender class
+	* @layout one of 'classic', 'html', 'xml', or 'pattern'
+	* @layoutArguments args for the layout
+	* @layoutClass A full class path to a Layout class
+	* @level log level
+	*/
+	function addLogger(
+		required string name,
+		string appender,
+		string appenderClass,
+		struct appenderArguments,
+		string layout,
+		struct layoutArguments,
+		string layoutClass,
+		string level
+	) {
+
+		var logger = {};
+		if( !isNull( appender ) ) { logger[ 'appender' ] = appender; };
+		if( !isNull( appenderArguments ) ) { logger[ 'appenderArguments' ] = appenderArguments; };
+		if( !isNull( appenderClass ) ) { logger[ 'appenderClass' ] = appenderClass; };
+		if( !isNull( layout ) ) { logger[ 'layout' ] = layout; };
+		if( !isNull( layoutArguments ) ) { logger[ 'layoutArguments' ] = layoutArguments; };
+		if( !isNull( layoutClass ) ) { logger[ 'layoutClass' ] = layoutClass; };
+		if( !isNull( level ) ) { logger[ 'level' ] = level; };
+
+		var thisLoggers = getLoggers() ?: {};
+		thisLoggers[ arguments.name ] = logger;
+		setLoggers( thisLoggers );
+		return this;
+	}
+
 	/**
 	* Get a struct representation of the config settings
 	*/

--- a/models/BaseLucee.cfc
+++ b/models/BaseLucee.cfc
@@ -104,6 +104,9 @@ component accessors=true extends='cfconfig-services.models.BaseConfig' {
 		var thisCache = xmlSearch( thisConfig, '/cfLuceeConfiguration/cache' );
 		if( thisCache.len() ){ readCache( thisCache[ 1 ] ); }
 		
+		var logging = xmlSearch( thisConfig, '/cfLuceeConfiguration/logging' );
+		if( logging.len() ){ readLoggers( logging[ 1 ] ); }
+
 		readAuth( thisConfig.XMLRoot );
 		
 		readConfigChanges( thisConfig.XMLRoot );
@@ -320,6 +323,26 @@ component accessors=true extends='cfconfig-services.models.BaseConfig' {
 					
 	}
 	
+	private function readLoggers( loggers ) {
+		for ( var logger in loggers.XMLChildren ) {
+			var attrStruct = structNew().append( logger.XMLAttributes );
+			var params = { };
+
+			for ( var attrName in attrStruct ) {
+				var paramKey = REReplace( attrName, '-([ac])', '\U\1', 'all' );
+				if ( attrName.listLast( '-' ) == 'arguments' ) {
+					params[ paramKey ] = { };
+					for ( var arg in attrStruct[ attrName ].listToArray( ';' ) ) {
+						params[ paramKey ][ arg.listFirst( ':' ) ] = arg.listRest( ':' );
+					}
+				} else {
+					params[ paramKey ] = attrStruct[ attrName ];
+				}
+			}
+			addLogger( argumentCollection = params );
+		}
+	}
+
 	/**
 	* I write out config
 	*
@@ -803,6 +826,47 @@ component accessors=true extends='cfconfig-services.models.BaseConfig' {
 		}
 	}
 	
+	private function writeLoggers( thisConfig ) {
+		var loggers = xmlSearch( thisConfig, '/cfLuceeConfiguration/logging' )[ 1 ].XMLChildren;
+
+		for( var name in getLoggers() ?: {} ) {
+			var loggerStruct = getLoggers()[ name ];
+			// Search to see if this logger already exists
+			var loggerXMLSearch = xmlSearch( thisConfig, "/cfLuceeConfiguration/logging/logger[translate(@name,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')='#lcase( name )#']" );
+			// logger already exists
+			if( loggerXMLSearch.len() ) {
+				loggerXMLNode = loggerXMLSearch[ 1 ];
+				// Wipe out old attributes for this logging
+				structClear( loggerXMLNode.XMLAttributes );
+			// Create new logger tag
+			} else {
+				var loggerXMLNode = xmlElemnew( thisConfig, "logger" );
+			}
+
+			// Populate XML node
+			loggerXMLNode.XMLAttributes[ 'name' ] = name;
+			for ( var key in [ 'appender', 'appenderClass', 'layout', 'layoutClass', 'level' ] ) {
+				if ( !isNull( loggerStruct[ key ] ) ) { 
+					loggerXMLNode.XMLAttributes[ key.replace( 'C', '-c' ) ] = loggerStruct[ key ]; 
+				}
+			}
+			for ( var key in [ 'appenderArguments', 'layoutArguments' ] ) {
+				if ( !isNull( loggerStruct[ key ] ) && isStruct( loggerStruct[ key ] ) ) {
+					var args = [ ];
+					for ( var argName in loggerStruct[ key ] ) {
+						args.append( argName & ':' & loggerStruct[ key ][ argName ] );
+					}
+					loggerXMLNode.XMLAttributes[ key.replace( 'A', '-a' ) ] = args.toList( ';' ); 
+				}
+			}
+
+			// Insert into doc if this was new.
+			if( !loggerXMLSearch.len() ) {
+				loggers.append( loggerXMLNode );
+			}
+		}
+	}
+
 	/**
 	* I find the actual Lucee 4.x context config file
 	*/

--- a/models/BaseLucee.cfc
+++ b/models/BaseLucee.cfc
@@ -329,7 +329,8 @@ component accessors=true extends='cfconfig-services.models.BaseConfig' {
 			var params = { };
 
 			for ( var attrName in attrStruct ) {
-				var paramKey = REReplace( attrName, '-([ac])', '\U\1', 'all' );
+				// translate from {var}-arguments and {var}-class to {var}Arguments and {var}Class
+				var paramKey = REReplace( attrName, '-([ac])', '\U\1' );
 				if ( attrName.listLast( '-' ) == 'arguments' ) {
 					params[ paramKey ] = { };
 					for ( var arg in attrStruct[ attrName ].listToArray( ';' ) ) {
@@ -847,6 +848,7 @@ component accessors=true extends='cfconfig-services.models.BaseConfig' {
 			loggerXMLNode.XMLAttributes[ 'name' ] = name;
 			for ( var key in [ 'appender', 'appenderClass', 'layout', 'layoutClass', 'level' ] ) {
 				if ( !isNull( loggerStruct[ key ] ) ) { 
+                    // replace() translates {var}Class to {var}-class
 					loggerXMLNode.XMLAttributes[ key.replace( 'C', '-c' ) ] = loggerStruct[ key ]; 
 				}
 			}
@@ -856,6 +858,7 @@ component accessors=true extends='cfconfig-services.models.BaseConfig' {
 					for ( var argName in loggerStruct[ key ] ) {
 						args.append( argName & ':' & loggerStruct[ key ][ argName ] );
 					}
+                    // replace() translates {var}Arguments to {var}-arguments
 					loggerXMLNode.XMLAttributes[ key.replace( 'A', '-a' ) ] = args.toList( ';' ); 
 				}
 			}


### PR DESCRIPTION
Adds support for the lucee logger configuration. 

One possible thing that should still be addressed is URL encoding the settings. I have noticed that the default settings for the loggers in Lucee are not URL encoded, but if you make changes they do end up URL encoded. 