### PR TITLE
Fix formatJson error for 'cfconfig show' w/out arguments

### DIFF
--- a/models/BaseConfig.cfc
+++ b/models/BaseConfig.cfc
@@ -18,6 +18,7 @@ component accessors="true" {
 
 	property name='wirebox' inject='wirebox';
 	property name='Util' inject='Util@cfconfig-services';
+	property name='JSONPrettyPrint' inject='JSONPrettyPrint@JSONPrettyPrint';
 
 	// ----------------------------------------------------------------------------------------
 	// Properties for the internal workings
@@ -893,7 +894,7 @@ component accessors="true" {
 	* Get a formatted string JSON representation of the config settings
 	*/
 	function toString(){
-		return getUtil().formatJson( getMemento() );
+		return getJSONPrettyPrint().formatJson( getMemento() );
 	}
 
 	/**

--- a/models/providers/JSONConfig.cfc
+++ b/models/providers/JSONConfig.cfc
@@ -10,9 +10,6 @@
 */
 component accessors=true extends='cfconfig-services.models.BaseConfig' {
 	
-	// DI
-	property name='JSONPrettyPrint' inject='JSONPrettyPrint@JSONPrettyPrint';
-	
 	/**
 	* Constructor
 	*/


### PR DESCRIPTION
Running 'cfconfig show' on a built in CommandBox server resulted in the Error 'cfconfig-services.models.Util' has no function with name formatJson.

Commit 70753aa 'Update to use JSONPrettyPrint module' removed the function formatJson from models/Utils

This commit solves this problem by moving JSONPrettyPrint into BaseConfig.cfc so it can be used by toString().