### PR TITLE
Adding instructions on how to run this library as independent project

### DIFF
--- a/box.json
+++ b/box.json
@@ -35,9 +35,11 @@
         "coldbox":"coldbox/",
         "propertyFile":"modules/propertyFile/",
         "semver":"modules/semver/",
-        "JSONPrettyPrint":"modules/JSONPrettyPrint/"
+        "JSONPrettyPrint":"modules/JSONPrettyPrint/",
+        "testbox":"testbox"
     },
     "devDependencies":{
-        "coldbox":"^4.3.0+188"
+        "coldbox":"^4.3.0+188",
+        "testbox":"^3.1.0"
     }
 }

--- a/readme.md
+++ b/readme.md
@@ -149,5 +149,5 @@ The code in this library has only been tested on Lucee and likely doesn't work o
 Individuals who would like to contribute to this library can follow the steps below to configure this tool to run independently for the purposes of extending and testing the code:
 
 1. This package currently depends on a `cfconfig.local` host entry.  You can add this to your system's `hosts` file manually or leverage a tool like [Commandbox HostUpdater](https://www.forgebox.io/view/commandbox-hostupdater) to add the host entry.
-2. Start up this project with commandBox using `server start` - this will open a browser to the test runner for this project.
+2. Start up this project with CommandBox using `server start` - this will open a browser to the test runner for this project.
 3. Happy Contributing!

--- a/readme.md
+++ b/readme.md
@@ -143,3 +143,11 @@ C:/ColdFusion11/cfusion/
 ```
 
 The code in this library has only been tested on Lucee and likely doesn't work on Adobe ColdFusion.  If anyone wants to make it compatible, feel free to try by beware of tons of use of the Elvis operator, reliance on sorted JSON structs, and some specific WDDX behavior.
+
+## Extending this module/service
+
+Individuals who would like to contribute to this library can follow the steps below to configure this tool to run independently for the purposes of extending and testing the code:
+
+1. This package currently depends on a `cfconfig.local` host entry.  You can add this to your system's `host` file manually or leverage a tool like [Commandbox HostUpdater](https://www.forgebox.io/view/commandbox-hostupdater) to add the host entry.
+2. Start up this project with commandBox using `server start` - this will open a browser to the test runner for this project.
+3. Happy Contributing!

--- a/readme.md
+++ b/readme.md
@@ -148,6 +148,6 @@ The code in this library has only been tested on Lucee and likely doesn't work o
 
 Individuals who would like to contribute to this library can follow the steps below to configure this tool to run independently for the purposes of extending and testing the code:
 
-1. This package currently depends on a `cfconfig.local` host entry.  You can add this to your system's `host` file manually or leverage a tool like [Commandbox HostUpdater](https://www.forgebox.io/view/commandbox-hostupdater) to add the host entry.
+1. This package currently depends on a `cfconfig.local` host entry.  You can add this to your system's `hosts` file manually or leverage a tool like [Commandbox HostUpdater](https://www.forgebox.io/view/commandbox-hostupdater) to add the host entry.
 2. Start up this project with commandBox using `server start` - this will open a browser to the test runner for this project.
 3. Happy Contributing!


### PR DESCRIPTION
I have some ideas on extending the CFConfig module to include some additional data points, but in order to do that I first needed to get this service library to run locally as a stand-alone project.  When I tried to run it "out of the box" (PUN TOTALLY INTENDED), I ran into a couple of issues with missing dependencies (testbox) and a hard-coded hosts entry in `server.json`.  

I made the following changes in order to resolve this issues:
* Adding a `box.json` devDependency for testbox (since the index.cfm page directs to the test runner)
* Adding instructions in the `README.md` for setting up the cfconfig.local hosts entry (not sure if this is still required, but I assumed there was a reason for the specific host entry in `server.json` and I didn't want to mess with that.

I noticed that Brad has an install script in box.json that updates his Commandbox modules in situ in a running CommandBox instance - this seems like a pretty elegant solution to testing the code, but the pathing was hard coded and I didn't want to change that without Brad's blessing.
