### PR TITLE
Add `com.mysql.cj.jdbc.Driver` as a valid MySQL Class

### DIFF
--- a/models/BaseLucee.cfc
+++ b/models/BaseLucee.cfc
@@ -1278,7 +1278,12 @@ component accessors=true extends='cfconfig-services.models.BaseConfig' {
 				return 'oracle.jdbc.driver.OracleDriver';
 			case 'MySQL' :
 				// If one of the known Lucee MySQL class names are in use, stick with it
-				if( listFindNoCase( 'com.mysql.jdbc.Driver,org.gjt.mm.mysql.Driver', className ) ) {
+				var knownMySQLClasses = arrayToList( [
+				    'com.mysql.jdbc.Driver',
+				    'org.gjt.mm.mysql.Driver',
+				    'com.mysql.cj.jdbc.Driver'
+				] );
+				if( listFindNoCase( knownMySQLClasses, className ) ) {
 					return className;
 				}
 				// If the class name wasn't recognized, default to this one.


### PR DESCRIPTION
Unknown MySQL classes are defaulted to `com.mysql.jdbc.Driver`, which doesn't work with MySQL 8.

On a related note, I wonder if a class is provided if we should always use it and only provide a class
if only a driver was set.