### PR TITLE
Adds max mail threads option for Adobe® ColdFusion® 10™

### DIFF
--- a/models/BaseAdobe.cfc
+++ b/models/BaseAdobe.cfc
@@ -589,6 +589,7 @@ component accessors=true extends='cfconfig-services.models.BaseConfig' {
 		if( !isNull( thisConfig.keypassword ) ) { setMailSignKeyPassword( passwordManager.decryptMailServer( thisConfig.keypassword ) ); }
 		if( !isNull( thisConfig.mailsentloggingenable ) ) { setMailLogEnabled( thisConfig.mailsentloggingenable ); }
 		if( !isNull( thisConfig.severity ) ) { setMailLogSeverity( thisConfig.severity ); }
+		if( !isNull( thisConfig.maxthreads ) ) { setMailMaxThreads( thisConfig.maxthreads ); }
 
 
 		if( !isNull( thisConfig.server ) && thisConfig.server.len() ) {
@@ -1420,6 +1421,7 @@ component accessors=true extends='cfconfig-services.models.BaseConfig' {
 		if( !isNull( getMailSignKeyPassword() ) ) { thisConfig.keypassword = passwordManager.encryptMailServer( getMailSignKeyPassword() ); }
 		if( !isNull( getMailLogEnabled() ) ) { thisConfig.mailsentloggingenable = getMailLogEnabled() ? true : false; }
 		if( !isNull( getMailLogSeverity() ) ) { thisConfig.severity = getMailLogSeverity(); }
+		if( !isNull( getMailMaxThreads() ) ) { thisConfig.maxthreads = getMailMaxThreads(); }
 
 
 		// Adobe can only store 1 mail server, so ignore any others.

--- a/models/BaseConfig.cfc
+++ b/models/BaseConfig.cfc
@@ -235,7 +235,8 @@ component accessors="true" {
 	// Error Log Severity. Select the type of SMTP-related error messages to log.
 	// One of the strings "debug", "information", "warning", "error"
 	property name='mailLogSeverity' type='string' _isCFConfig=true;
-
+	// Number of mail delivery threads
+	property name='mailMaxThreads' type='numeric' _isCFConfig=true;
 
 
 	// Key is virtual path, value is struct of properties

--- a/tests/resources/adobe10/serverHome/WEB-INF/cfusion/lib/neo-mail.xml
+++ b/tests/resources/adobe10/serverHome/WEB-INF/cfusion/lib/neo-mail.xml
@@ -11,6 +11,9 @@
       <var name="usetls">
         <boolean value="false"/>
       </var>
+      <var name="maxthreads">
+        <number>10.0</number>
+      </var>
       <var name="undeliverdir">
         <string>{neo.rootdir}/Mail/Undelivr</string>
       </var>


### PR DESCRIPTION
I encountered difficulty when attempting to set the value using `${MY_ENV:10}`. When a number is hard-coded into `.cfconfig.json`, it works fine on Adobe® ColdFusion® 10™. Feel free to disregard.