### PR TITLE
update latest engine versions listed

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ CFConfig covers most of the common settings you'll find in Adobe and Lucee serve
 The current list of supported engines is:
 
 * **Adobe ColdFusion 9, 10, 11, 2016, 2018, 2021**
-* **Lucee 4, 5**
+* **Lucee 4, 5, 6**
 * **Railo 4**
 
 If you find a setting or feature which is not supported, please send a pull request or add a ticket so we can track it. 
@@ -65,6 +65,8 @@ Not all the data it stores applies to every engine though.  The `BaseConfig.cfc`
 * **Lucee4Web.cfc** - Lucee 4.x web context
 * **Lucee5Server.cfc** - Lucee 5.x server context
 * **Lucee5Web.cfc** - Lucee 5.x web context
+* **Lucee6Server.cfc** - Lucee 6.x server context
+* **Lucee6Web.cfc** - Lucee 6.x web context
 * **Railo4Server.cfc** - Railo 4.x server context
 * **Railo4Web.cfc** - Railo 4.x web context
 * **Adobe9.cfc** - Adobe ColdFusion 9

--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ CFConfig covers most of the common settings you'll find in Adobe and Lucee serve
 
 The current list of supported engines is:
 
-* **Adobe ColdFusion 9, 10, 11, 2016, 2018**
+* **Adobe ColdFusion 9, 10, 11, 2016, 2018, 2021**
 * **Lucee 4, 5**
 * **Railo 4**
 
@@ -72,6 +72,7 @@ Not all the data it stores applies to every engine though.  The `BaseConfig.cfc`
 * **Adobe11.cfc** - Adobe ColdFusion 11
 * **Adobe2016.cfc** - Adobe Coldfusion 2016
 * **Adobe2018.cfc** - Adobe Coldfusion 2018
+* **Adobe2021.cfc** - Adobe Coldfusion 2021
 
 ## Usage
 


### PR DESCRIPTION
You'll notice I have offered the Lucee 6 one as a separate commit, in case you're not ready yet to indicate that as supported. I just found it here while noticing first that CF2021 was not yet listed on this page.

Also, assuming you are prepared to accept that change, I didn't know myself whether/how to change the couple of other references on this page to Lucee versions, so you'll want to tweak those as an additional update if those should now also refer to 6. See for example, "_The Lucee 4 and Lucee 5 *web* components expect the `CFHomePath` to be the folder containing the `lucee-web.xml.cfm` file._"

PS I don't know why the final line of the file shows as being changed by me (removed and added back). I didn't touch that, but I'm doing this edit in the github web ui, and it's a pain to sort that out. As long as you agree that there's "no change" made, I guess we can just ignore it as an oddity. If you feel otherwise, let me know and we'll sort it out somehow.