### PR TITLE
BaseConfig - Add support for timezone passthrough in addDatasource()

### DIFF
--- a/models/BaseConfig.cfc
+++ b/models/BaseConfig.cfc
@@ -1038,6 +1038,7 @@ component accessors="true" {
 	* @requestExclusive Exclusive connections for request
 	* @bundleName OSGI bundle name to load the class from
 	* @bundleVersion OSGI bundle version to load the class from
+	* @timezone Timezone for this datasource, used for datetime value coercion
 	*
 	* logActivity notes
 	* ;SpyAttributes=(log=(file)C:/foobar.txt; linelimit=80;logTName=yes;timestamp=yes)</
@@ -1095,7 +1096,8 @@ component accessors="true" {
 			string description,
 			boolean requestExclusive,
 			string bundleName,
-			string bundleVersion
+			string bundleVersion,
+			string timezone
 		) {
 		var ds = {};
 		if( !isNull( database ) ) { ds[ 'database' ] = database; };
@@ -1152,6 +1154,7 @@ component accessors="true" {
 		if( !isNull( requestExclusive ) ) { ds[ 'requestExclusive' ] = requestExclusive; };
 		if( !isNull( bundleName ) ) { ds[ 'bundleName' ] = bundleName; };
 		if( !isNull( bundleVersion ) ) { ds[ 'bundleVersion' ] = bundleVersion; };
+		if( !isNull( timezone ) ) { ds[ 'timezone' ] = timezone; };
 
 		var thisDatasources = getDataSources() ?: {};
 		thisDatasources[ arguments.name ] = ds;


### PR DESCRIPTION
Adds support for reading/writing the `timezone` property on a datasource.