### PR TITLE
CFCONFIG-72 fix datasource DSN switch fall-through in Lucee6Server

### DIFF
--- a/models/providers/Lucee6Server.cfc
+++ b/models/providers/Lucee6Server.cfc
@@ -308,22 +308,28 @@ component accessors=true extends='cfconfig-services.models.BaseConfig' {
 					switch( translateDatasourceDriverToLucee( datasource.dbdriver ) ) {
 						case 'MySQL' :
 							datasource[ 'dsn' ] = 'jdbc:mysql://{host}:{port}/{database}';
+							break;
 						case 'Oracle' :
-							if( len( datasource.SID ) ) {
+							if( len( datasource.SID ?: '' ) ) {
 								datasource[ 'dsn' ] = 'jdbc:oracle:{drivertype}:@{host}:{port}:#datasource.SID#';
-							} else if( len( datasource.serviceName ) ) {
+							} else if( len( datasource.serviceName ?: '' ) ) {
 								datasource[ 'dsn' ] = 'jdbc:oracle:{drivertype}:@{host}:{port}/#datasource.serviceName#';
 							} else {
 								datasource[ 'dsn' ] = 'jdbc:oracle:{drivertype}:@{host}:{port}:{database}';
 							}
+							break;
 						case 'PostgreSql' :
 							datasource[ 'dsn' ] = 'jdbc:postgresql://{host}:{port}/{database}';
+							break;
 						case 'MSSQL' :
 							datasource[ 'dsn' ] = 'jdbc:sqlserver://{host}:{port}:databaseName={database}';
+							break;
 						case 'JTDS' :
 							datasource[ 'dsn' ] = 'jdbc:jtds:sqlserver://{host}:{port}/{database}';
+							break;
 						case 'H2' :
 							datasource[ 'dsn' ] = 'jdbc:h2:{path}{database};MODE={mode}';
+							break;
 						default :
 							datasource[ 'dsn' ] = '';
 					}

--- a/tests/specs/Lucee6ServerConfigTest.cfc
+++ b/tests/specs/Lucee6ServerConfigTest.cfc
@@ -89,6 +89,92 @@ component extends="tests.BaseTest" appMapping="/tests" {
 
 			});
 
+			it( "should write correct DSN for each datasource driver without switch fall-through", function() {
+				var Lucee6ServerConfig = getInstance( 'Lucee6Server@cfconfig-services' );
+				var testConfig = {
+					datasources: {
+						"testMySQL": {
+							dbdriver: "MySQL",
+							host: "127.0.0.1",
+							port: "3306",
+							database: "mydb",
+							username: "root",
+							password: "pass",
+							class: "com.mysql.cj.jdbc.Driver"
+						},
+						"testOracle": {
+							dbdriver: "Oracle",
+							host: "127.0.0.1",
+							port: "1521",
+							database: "orcl",
+							username: "sys",
+							password: "pass",
+							class: "oracle.jdbc.OracleDriver",
+							SID: "ORCL"
+						},
+						"testOracleServiceName": {
+							dbdriver: "Oracle",
+							host: "127.0.0.1",
+							port: "1521",
+							database: "orcl",
+							username: "sys",
+							password: "pass",
+							class: "oracle.jdbc.OracleDriver",
+							SID: "",
+							serviceName: "myservice"
+						},
+						"testPostgreSQL": {
+							dbdriver: "PostgreSQL",
+							host: "127.0.0.1",
+							port: "5432",
+							database: "pgdb",
+							username: "postgres",
+							password: "pass",
+							class: "org.postgresql.Driver"
+						},
+						"testMSSQL": {
+							dbdriver: "MSSQL",
+							host: "127.0.0.1",
+							port: "1433",
+							database: "msdb",
+							username: "sa",
+							password: "pass",
+							class: "com.microsoft.sqlserver.jdbc.SQLServerDriver"
+						},
+						"testMSSQL2": {
+							dbdriver: "MSSQL2",
+							host: "127.0.0.1",
+							port: "1433",
+							database: "msdb",
+							username: "sa",
+							password: "pass",
+							class: "net.sourceforge.jtds.jdbc.Driver"
+						},
+						"testH2": {
+							dbdriver: "H2",
+							host: "127.0.0.1",
+							port: "9092",
+							database: "h2db",
+							username: "sa",
+							password: "",
+							class: "org.h2.Driver"
+						}
+					}
+				};
+				Lucee6ServerConfig.setMemento( testConfig );
+				Lucee6ServerConfig.write( expandPath( '/tests/resources/tmp' ) );
+
+				var output = deserializeJSON( fileRead( expandPath( '/tests/resources/tmp/context/.CFConfig.json' ) ) );
+
+				expect( output.datasources[ "testMySQL" ].dsn ).toBe( "jdbc:mysql://{host}:{port}/{database}" );
+				expect( output.datasources[ "testOracle" ].dsn ).toBe( "jdbc:oracle:{drivertype}:@{host}:{port}:ORCL" );
+				expect( output.datasources[ "testOracleServiceName" ].dsn ).toBe( "jdbc:oracle:{drivertype}:@{host}:{port}/myservice" );
+				expect( output.datasources[ "testPostgreSQL" ].dsn ).toBe( "jdbc:postgresql://{host}:{port}/{database}" );
+				expect( output.datasources[ "testMSSQL" ].dsn ).toBe( "jdbc:sqlserver://{host}:{port}:databaseName={database}" );
+				expect( output.datasources[ "testMSSQL2" ].dsn ).toBe( "jdbc:jtds:sqlserver://{host}:{port}/{database}" );
+				expect( output.datasources[ "testH2" ].dsn ).toBe( "jdbc:h2:{path}{database};MODE={mode}" );
+			});
+
 			it( "should export scheduledTasks as array and gateways as struct (CFCONFIG-64)", function() {
 				var Lucee6ServerConfig = getInstance( 'Lucee6Server@cfconfig-services' );
 				var testConfig = {


### PR DESCRIPTION
## Summary

- Fix missing `break` statements in the datasource DSN translation switch in `Lucee6Server.cfc` (introduced in #65)
- Add null-safe access for Oracle `SID`/`serviceName` keys (`?: ''`) matching the pattern used in `BoxLang1.cfc`
- Add test covering all 7 driver cases (MySQL, Oracle w/ SID, Oracle w/ serviceName, PostgreSQL, MSSQL, MSSQL2/JTDS, H2)

https://ortussolutions.atlassian.net/browse/CFCONFIG-72

## Problem

Without `break` statements, every case falls through. A MySQL datasource ends up in the Oracle case which throws `key [SID] doesn't exist`, preventing the server from starting.

## Test plan

- [x] New test fails before fix (confirms fall-through)
- [x] New test passes after fix (all 7 drivers get correct DSN)
- [x] All existing Lucee6ServerConfigTest specs still pass